### PR TITLE
Add simple scraper with usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ## Hi there 👋
 
 <!--
-**kaneko424/kaneko424** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+**kaneko424/kaneko424** is a ✨ _special_ ✨ repository because its `README.md`
+(this file) appears on your GitHub profile.
 
 Here are some ideas to get you started:
 
@@ -14,3 +15,31 @@ Here are some ideas to get you started:
 - 😄 Pronouns: ...
 - ⚡ Fun fact: ...
 -->
+
+## Web Scraper
+
+This repository includes a simple Python script, `scraper.py`, that fetches a web page and prints the headings (``<h1>`` to ``<h3>``) found on that page.
+
+### Requirements
+
+- Python 3.7+
+- [`requests`](https://pypi.org/project/requests/)
+- [`beautifulsoup4`](https://pypi.org/project/beautifulsoup4/)
+
+Install dependencies using:
+
+```bash
+pip install -r requirements.txt
+```
+
+### Usage
+
+```bash
+python scraper.py https://example.com
+```
+
+This will print the headings retrieved from the provided URL.
+
+### Disclaimer
+
+Please respect each website's terms of service when running this script. Some sites prohibit automated scraping. Always check and comply with the website's robots.txt and any other applicable policies.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,46 @@
+import requests
+from bs4 import BeautifulSoup
+from typing import List
+
+
+def fetch_titles(url: str) -> List[str]:
+    """Fetch headings (h1-h3) from the given URL.
+
+    Parameters
+    ----------
+    url : str
+        Web page URL to scrape.
+
+    Returns
+    -------
+    list of str
+        List of heading texts found on the page.
+    """
+    response = requests.get(url)
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.text, 'html.parser')
+    headings = []
+    for tag in soup.find_all(['h1', 'h2', 'h3']):
+        text = tag.get_text(strip=True)
+        if text:
+            headings.append(text)
+    return headings
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 2:
+        print("Usage: python scraper.py <URL>")
+        sys.exit(1)
+
+    url = sys.argv[1]
+    try:
+        titles = fetch_titles(url)
+        for title in titles:
+            print(title)
+    except Exception as exc:
+        print(f"Error fetching {url}: {exc}")
+        sys.exit(1)
+


### PR DESCRIPTION
## Summary
- add `scraper.py` to fetch headings from a webpage using `requests` and `BeautifulSoup`
- document running instructions and TOS disclaimer in `README.md`
- include `requirements.txt` listing Python dependencies

## Testing
- `python3 -m py_compile scraper.py`
- `pip install requests beautifulsoup4` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6889488c2bfc83218b6833ba9497f138